### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     install_requires=open('requirements.txt').read().strip().split('\n'),
     include_package_data=True

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,4 +2,6 @@
 python_files = tests_*.py
 filterwarnings =
     error
+    always::DeprecationWarning
+    always::PendingDeprecationWarning
 

--- a/tests/tests_argparser.py
+++ b/tests/tests_argparser.py
@@ -2,6 +2,7 @@
 Tests for the argument parser
 """
 import subprocess
+
 import pytest
 
 from excels2vensim.cli import parser

--- a/tests/tests_excels2vensim.py
+++ b/tests/tests_excels2vensim.py
@@ -5,10 +5,10 @@ import os
 import sys
 import subprocess
 import shutil
-from pysd import read_vensim
-import numpy as np
 
 import pytest
+import numpy as np
+from pysd import read_vensim
 
 import excels2vensim as e2v
 
@@ -217,10 +217,10 @@ def test_non_valid_chars(tmp_path, _root):
     assert "CONSTANTS('inputs_nvc.xlsx', 'Region1', 'my_q_row')" in out
 
     # invalid dim name
-    with pytest.warns(UserWarning) as records:
+    with pytest.warns(UserWarning) as record:
         out = e2v.load_from_json(_root / 'jsons' / 'constants_nvc.json')
 
-    assert len(records) == 2
+    record = [str(r.message) for r in record]
 
     expected = [
         "The name of the subscript '\"  Elec/el\"' has special characters. "
@@ -228,8 +228,8 @@ def test_non_valid_chars(tmp_path, _root):
         "The name of the subscript '\"Solid$\"' has special characters. "
         + "'Solid' will be used for cellrange names."]
 
-    for record in records:
-        assert record.message.args[0] in expected
+    for message in expected:
+        assert message in record
 
     assert "share_energy[source, sector, Region3, \"  Elec/el\"]=\n\t"\
         + "GET_DIRECT_CONSTANTS('inputs_nvc.xlsx', 'Region3',"\
@@ -252,7 +252,7 @@ def test_non_valid_chars(tmp_path, _root):
     expected = r"The name of the interpolation dimension 'my time\$'"\
                + r" has special characters\. 'my_time' will be used for "\
                + r"cellrange names\."
-    with pytest.warns(UserWarning, match=expected) as records:
+    with pytest.warns(UserWarning, match=expected):
         out = e2v.load_from_json(_root / 'jsons' / 'data_nvseries.json')
 
     assert "DATA('inputs_data_nvs.xlsx', 'GPH', 'my_time',"\


### PR DESCRIPTION
## Description

Add support for Python 3.12


## Type of change

- Other

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [ ] The new code has been tested properly for all the possible cases
- [ ] The overall coverage has not dropped and other features have not been broken
- [ ] If new features have been added, they have been properly documented
- [ ] Version has been updated
